### PR TITLE
Use the geo.mirror.pkgbuild.com mirror

### DIFF
--- a/etc/pacman.d/mirrorlist
+++ b/etc/pacman.d/mirrorlist
@@ -3,5 +3,5 @@
 ##
 
 Server = https://mirror.internal.herecura.eu/$repo/os/$arch
-Server = https://mirror.pkgbuild.com/$repo/os/$arch
+Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
 Server = https://mirror.ams1.nl.leaseweb.net/archlinux/$repo/os/$arch

--- a/packer-desktop.json
+++ b/packer-desktop.json
@@ -1,8 +1,8 @@
 {
     "variables": {
-        "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
-        "iso_checksum_url": "https://mirror.pkgbuild.com/iso/latest/sha1sums.txt",
-        "install_mirror": "https://mirror.pkgbuild.com/$repo/os/$arch",
+        "iso_url": "https://geo.mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
+        "iso_checksum_url": "https://geo.mirror.pkgbuild.com/iso/latest/sha1sums.txt",
+        "install_mirror": "https://geo.mirror.pkgbuild.com/$repo/os/$arch",
         "disk_size": "40960",
         "headless": "true",
         "boot_wait": "40s",

--- a/packer-server.json
+++ b/packer-server.json
@@ -1,8 +1,8 @@
 {
     "variables": {
-        "iso_url": "https://mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
-        "iso_checksum_url": "https://mirror.pkgbuild.com/iso/latest/sha1sums.txt",
-        "install_mirror": "https://mirror.pkgbuild.com/$repo/os/$arch",
+        "iso_url": "https://geo.mirror.pkgbuild.com/iso/latest/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
+        "iso_checksum_url": "https://geo.mirror.pkgbuild.com/iso/latest/sha1sums.txt",
+        "install_mirror": "https://geo.mirror.pkgbuild.com/$repo/os/$arch",
         "disk_size": "20480",
         "headless": "true",
         "boot_wait": "40s",


### PR DESCRIPTION
geo.mirror.pkgbuild.com is a GeoDNS mirror that points to sponsored mirrors.

This avoids the usage of Arch's infrastructure (mirror.pkgbuild.com) for large downloads.
See https://gitlab.archlinux.org/archlinux/infrastructure/-/merge_requests/522 for details.
